### PR TITLE
Increase pfind dialog box size to show correctly

### DIFF
--- a/woof-code/rootfs-packages/pfind/usr/local/pfind/pfindrc
+++ b/woof-code/rootfs-packages/pfind/usr/local/pfind/pfindrc
@@ -19,7 +19,7 @@ export PATH_PUPPY='/bin [OR] /etc [OR] /lib [OR] /lib64 [OR] /opt [OR] /sbin [OR
 export PATH_MNT='/mnt/ [OR] /root'
 
 #geometry
-export HEIGHT="450"
-export WIDTH="700"
+export HEIGHT="750"
+export WIDTH="950"
 export X=""
 export Y=""


### PR DESCRIPTION
Increase pfind dialog box size to show correctly. 450x700 is to small. 750x950 shows the entire app without having to resize every time.